### PR TITLE
Update ci test workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,25 +19,15 @@ jobs:
     strategy:
       matrix:
         include:
-          # iRODS 4.2.10 clients vs 4.2.7 server
-          - irods: "4.2.10"
-            server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "3.2.0"
-            experimental: false
-          # iRODS 4.2.10 clients vs 4.2.10 server
-          - irods: "4.2.10"
-            server_image: "wsinpg/ub-18.04-irods-4.2.10:latest"
-            baton: "3.2.0"
-            experimental: false
           # iRODS 4.2.11 clients vs 4.2.7 server
           - irods: "4.2.11"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
           # iRODS 4.2.11 clients vs 4.2.11 server
           - irods: "4.2.11"
             server_image: "wsinpg/ub-18.04-irods-4.2.11:latest"
-            baton: "3.2.0"
+            baton: "3.3.0"
             experimental: false
 
     services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Removed
+ - Remove iRODS 4.2.10 from github actions workflow
 
 ### Changed
+ - Update baton version in github actions workflow to 3.3.0 
 
 ## [1.0.0]
 


### PR DESCRIPTION
Update baton version to 3.3.0 and remove irods 4.2.10 from actions test workflow