### PR TITLE
Add support for created/modified timestamps on DataObjects

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       WSI_CONDA_CHANNEL: "https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic"
       CONDA_TEST_ENVIRONMENT: "testenv"
-      PYTHON_VERSION=: "3.9"
+      PYTHON_VERSION=: "3.10"
 
     strategy:
       matrix:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+python-dateutil==2.8.2
 setuptools_scm==7.0.5
 structlog==22.1.0

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     use_scm_version=True,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     packages=find_packages("src"),
     package_dir={"": "src"},
     setup_requires=["setuptools_scm"],
-    install_requires=["structlog"],
+    install_requires=["python-dateutil", "structlog"],
     tests_require=["black", "pytest", "pytest-it"],
     scripts=[],
 )

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -494,6 +494,26 @@ class TestDataObject(object):
             assert r.checksum == "39a4aa291ca849d601e4e5b8ed627a04"
             assert r.valid
 
+    @m.it("Has a creation timestamp equal to the earliest replica creation time")
+    def test_creation_timestamp(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+
+        assert obj.created() == min([o.created for o in obj.replicas()])
+
+    @m.it(
+        "Has a modification timestamp equal to the earliest replica modification time"
+    )
+    def test_modification_timestamp(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+
+        assert obj.timestamp() == min([o.modified for o in obj.replicas()])
+
+    @m.it("Has a timestamp equal to the earliest replica modification time")
+    def test_timestamp(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+
+        assert obj.timestamp() == min([o.modified for o in obj.replicas()])
+
     @m.it("Can be overwritten")
     def test_overwrite_data_object(self, tmp_path, simple_data_object):
         obj = DataObject(simple_data_object)


### PR DESCRIPTION
Add created and modified attributes to Replica.
Add created, modified and timestamp methods to DataObject.
Add decoding of timestamps in baton JSON.
Remove some non-Pythonic use of keys() when checking dict membership.
Replace some use of some bare strings with attributes, in baton JSON creation.