### PR TITLE
Add replica trimming for DataObjects

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         include:
-          # iRODS 4.2.11 clients vs 4.2.7 server
-          - irods: "4.2.11"
+          # iRODS 4.2.7 clients vs 4.2.7 server
+          - irods: "4.2.7"
             server_image: "wsinpg/ub-16.04-irods-4.2.7:latest"
             baton: "4.0.0"
             experimental: false
@@ -113,4 +113,5 @@ jobs:
         conda activate "$CONDA_TEST_ENVIRONMENT"
 
         export PYTHONPATH=$PWD/src:$PWD:tests:$PYTHONPATH
+        export IRODS_VERSION="${{ matrix.irods }}"
         pytest --it

--- a/src/partisan/icommands.py
+++ b/src/partisan/icommands.py
@@ -102,8 +102,10 @@ def irm(remote_path: Union[PurePath, str], force=False, recurse=False):
     # absent, even when -f is used. This should be silent for a missing target.
     try:
         _run(cmd)
-    except RodsError:
-        if not force:
+    except RodsError as re:
+        if force:
+            log.error(re.message, code=re.code)
+        else:
             raise
 
 
@@ -148,12 +150,9 @@ def iquest(*args) -> str:
 def has_specific_sql(alias) -> bool:
     """Return True if iRODS has a specific query installed under the alias."""
     existing = iquest("--sql", "ls")
+
     with StringIO(existing) as reader:
-        for line in reader:
-            line = line.strip()
-            if line == alias:
-                return True
-    return False
+        return any(line.strip() == alias for line in reader)
 
 
 def have_admin() -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2020, 2021 Genome Research Ltd. All rights reserved.
+# Copyright © 2020, 2021, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,19 +16,29 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # @author Keith James <kdj@sanger.ac.uk>
-
+#
 # From the pytest docs:
 #
 # "The conftest.py file serves as a means of providing fixtures for an entire
 # directory. Fixtures defined in a conftest.py can be used by any test in that
 # package without needing to import them (pytest will automatically discover
 # them)."
-
+import os
 from pathlib import PurePath
 
 import pytest
 
-from partisan.icommands import have_admin, imkdir, iput, irm, mkgroup, rmgroup
+from partisan.icommands import (
+    add_specific_sql,
+    have_admin,
+    imkdir,
+    iput,
+    iquest,
+    irm,
+    mkgroup,
+    remove_specific_sql,
+    rmgroup,
+)
 from partisan.irods import AVU, Collection, DataObject
 
 tests_have_admin = pytest.mark.skipif(
@@ -36,6 +46,9 @@ tests_have_admin = pytest.mark.skipif(
 )
 
 TEST_GROUPS = ["ss_study_01", "ss_study_02", "ss_study_03"]
+
+TEST_SQL_STALE_REPLICATE = "setObjectReplStale"
+TEST_SQL_INVALID_CHECKSUM = "setObjectChecksumInvalid"
 
 
 def add_test_groups():
@@ -50,12 +63,67 @@ def remove_test_groups():
             rmgroup(g)
 
 
+def add_sql_test_utilities():
+    if have_admin():
+        add_specific_sql(
+            TEST_SQL_STALE_REPLICATE,
+            "UPDATE r_data_main dm SET DATA_IS_DIRTY = 0 FROM r_coll_main cm "
+            "WHERE dm.coll_id = cm.coll_id "
+            "AND cm.COLL_NAME = ? "
+            "AND dm.DATA_NAME= ? "
+            "AND dm.DATA_REPL_NUM= ?",
+        )
+        add_specific_sql(
+            TEST_SQL_INVALID_CHECKSUM,
+            "UPDATE r_data_main dm SET DATA_CHECKSUM = 0 FROM r_coll_main cm "
+            "WHERE dm.coll_id = cm.coll_id "
+            "AND cm.COLL_NAME = ? "
+            "AND dm.DATA_NAME= ? "
+            "AND dm.DATA_REPL_NUM= ?",
+        )
+
+
+def remove_sql_test_utilities():
+    if have_admin():
+        remove_specific_sql(TEST_SQL_STALE_REPLICATE)
+        remove_specific_sql(TEST_SQL_INVALID_CHECKSUM)
+
+
 def add_rods_path(root_path: PurePath, tmp_path: PurePath) -> PurePath:
     parts = PurePath(*tmp_path.parts[1:])
     rods_path = root_path / parts
     imkdir(rods_path, make_parents=True)
 
     return rods_path
+
+
+def set_replicate_invalid(obj: DataObject, replicate_num: int):
+    iquest(
+        "--sql",
+        TEST_SQL_STALE_REPLICATE,
+        obj.path.as_posix(),
+        obj.name,
+        str(replicate_num),
+    )
+
+
+def set_checksum_invalid(obj: DataObject, replicate_num: int):
+    iquest(
+        "--sql",
+        TEST_SQL_INVALID_CHECKSUM,
+        obj.path.as_posix(),
+        obj.name,
+        str(replicate_num),
+    )
+
+
+@pytest.fixture(scope="session")
+def sql_test_utilities():
+    try:
+        add_sql_test_utilities()
+        yield
+    finally:
+        remove_sql_test_utilities()
 
 
 @pytest.fixture(scope="function")
@@ -115,6 +183,39 @@ def annotated_data_object(simple_data_object):
         yield simple_data_object
     finally:
         irm(simple_data_object, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def invalid_replica_data_object(tmp_path, sql_test_utilities):
+    """A fixture providing a data object with one of its two replicas marked invalid."""
+    root_path = PurePath("/testZone/home/irods/test")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    obj_path = rods_path / "invalid_replica.txt"
+    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
+    set_replicate_invalid(DataObject(obj_path), 1)
+
+    try:
+        yield obj_path
+    finally:
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
+def invalid_checksum_data_object(tmp_path, sql_test_utilities):
+    """A fixture providing a data object with one of its two replica's checksum
+    changed."""
+    root_path = PurePath("/testZone/home/irods/test")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    obj_path = rods_path / "invalid_checksum.txt"
+    iput("./tests/data/simple/data_object/lorem.txt", obj_path)
+    set_checksum_invalid(DataObject(obj_path), 1)
+
+    try:
+        yield obj_path
+    finally:
+        irm(root_path, force=True, recurse=True)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@
 # directory. Fixtures defined in a conftest.py can be used by any test in that
 # package without needing to import them (pytest will automatically discover
 # them)."
-import os
+
 from pathlib import PurePath
 
 import pytest
@@ -70,16 +70,16 @@ def add_sql_test_utilities():
             "UPDATE r_data_main dm SET DATA_IS_DIRTY = 0 FROM r_coll_main cm "
             "WHERE dm.coll_id = cm.coll_id "
             "AND cm.COLL_NAME = ? "
-            "AND dm.DATA_NAME= ? "
-            "AND dm.DATA_REPL_NUM= ?",
+            "AND dm.DATA_NAME = ? "
+            "AND dm.DATA_REPL_NUM = ?",
         )
         add_specific_sql(
             TEST_SQL_INVALID_CHECKSUM,
             "UPDATE r_data_main dm SET DATA_CHECKSUM = 0 FROM r_coll_main cm "
             "WHERE dm.coll_id = cm.coll_id "
             "AND cm.COLL_NAME = ? "
-            "AND dm.DATA_NAME= ? "
-            "AND dm.DATA_REPL_NUM= ?",
+            "AND dm.DATA_NAME = ? "
+            "AND dm.DATA_REPL_NUM = ?",
         )
 
 

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2020, 2021 Genome Research Ltd. All rights reserved.
+# Copyright © 2020, 2021, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -21,26 +21,30 @@ import hashlib
 import os.path
 from datetime import datetime
 from pathlib import PurePath
-from unittest.mock import patch
 
 import pytest
 from pytest import mark as m
 
 import partisan
+
 from partisan import irods
 from partisan.exception import BatonError, RodsError
 from partisan.irods import (
     AC,
     AVU,
-    Baton,
     Collection,
     DataObject,
     Permission,
-    format_timestamp,
     make_rods_item,
     query_metadata,
     rods_path_type,
 )
+
+
+def irods_version():
+    version = os.environ.get("IRODS_VERSION", "4.2.7")
+    [major, minor, patch] = [int(elt) for elt in version.split(".")]
+    return major, minor, patch
 
 
 @m.describe("AC")
@@ -487,26 +491,15 @@ class TestDataObject(object):
         assert obj.checksum(verify_checksum=True)
 
     @m.it("Can have its checksum verified as bad")
-    def test_verify_checksum_bad(self, simple_data_object):
-        obj = DataObject(simple_data_object)
+    @pytest.mark.skipif(
+        irods_version() <= (4, 2, 10), reason="requires iRODS server >4.2.10"
+    )
+    def test_verify_checksum_bad(self, invalid_checksum_data_object):
+        obj = DataObject(invalid_checksum_data_object)
 
-        # We are patching json.loads object hook for decoding baton.py JSON
-        decoded = {
-            Baton.OP: Baton.CHECKSUM,
-            Baton.ARGS: {"verify": True},
-            Baton.TARGET: {
-                Baton.COLL: simple_data_object.parent,
-                Baton.OBJ: simple_data_object.name,
-            },
-            Baton.RESULT: {Baton.SINGLE: None},
-            Baton.ERR: {Baton.MSG: "Checksum validation failed", Baton.CODE: -999},
-        }
-
-        with patch("partisan.irods.as_baton") as json_mock:
-            json_mock.return_value = decoded
-            with pytest.raises(RodsError) as info:
-                obj.checksum(verify_checksum=True)
-                assert info.value.code == decoded[Baton.ERR][Baton.CODE]
+        with pytest.raises(RodsError, match="checksum") as e:
+            obj.checksum(verify_checksum=True)
+        assert e.value.code == -407000  # CHECK_VERIFICATION_RESULTS
 
     @m.it("Has replicas")
     def test_replicas(self, simple_data_object):
@@ -516,6 +509,13 @@ class TestDataObject(object):
         for r in obj.replicas():
             assert r.checksum == "39a4aa291ca849d601e4e5b8ed627a04"
             assert r.valid
+
+    @m.it("Can have its invalid replicas detected")
+    def test_invalid_replica(self, invalid_replica_data_object):
+        obj = DataObject(invalid_replica_data_object)
+        (r0, r1) = obj.replicas()
+        assert r0.valid
+        assert not r1.valid
 
     @m.it("Has a creation timestamp equal to the earliest replica creation time")
     def test_creation_timestamp(self, simple_data_object):
@@ -703,6 +703,75 @@ class TestDataObject(object):
         assert obj.acl() == [AC(user, Permission.OWN, zone=zone)]
 
 
+@m.describe("Replica management")
+class TestReplicaManagement(object):
+    @m.describe("Data objects with valid replicas")
+    @m.context("When trimming would not violate the minimum replica count")
+    @m.it("Trims valid replicas")
+    def test_trim_valid_replica(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+        assert len(obj.replicas()) == 2
+
+        nv, ni = obj.trim_replicas(min_replicas=1, valid=False, invalid=False)  # noop
+        assert nv == ni == 0
+        assert len(obj.replicas()) == 2
+
+        nv, ni = obj.trim_replicas(min_replicas=1, valid=True, invalid=False)
+        assert nv == 1
+        assert ni == 0
+        assert len(obj.replicas()) == 1
+
+    @m.context("When trimming would violate the minimum replica count")
+    @m.it("Does not trim valid replicas")
+    def test_trim_valid_replica_min(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+        assert len(obj.replicas()) == 2
+
+        nv, ni = obj.trim_replicas(min_replicas=2, valid=True, invalid=False)
+        assert nv == ni == 0
+        assert len(obj.replicas()) == 2
+
+    @m.context("When there are no invalid replicas")
+    @m.it("Trims no valid replicas")
+    def test_trim_valid_replica_none(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+        assert len(obj.replicas()) == 2
+
+        nv, ni = obj.trim_replicas(min_replicas=2, valid=False, invalid=True)
+        assert nv == ni == 0
+        assert len(obj.replicas()) == 2
+
+        nv, ni = obj.trim_replicas(min_replicas=1, valid=False, invalid=True)
+        assert len(obj.replicas()) == 2
+        assert nv == ni == 0
+
+    @m.context("When trimming would remove all replicas")
+    @m.it("Raises an error")
+    def test_trim_valid_replica_zero(self, simple_data_object, sql_test_utilities):
+        obj = DataObject(simple_data_object)
+        assert len(obj.replicas()) == 2
+
+        with pytest.raises(RodsError, match="trim error"):
+            obj.trim_replicas(min_replicas=0, valid=True, invalid=False)
+
+    @m.describe("Data objects with invalid replicas")
+    @m.context("When trimming would violate the minimum replica count")
+    @m.it("Still trims invalid replicas")
+    def test_trim_invalid_replica(
+        self, invalid_replica_data_object, sql_test_utilities
+    ):
+        obj = DataObject(invalid_replica_data_object)
+        assert len(obj.replicas()) == 2
+
+        nv, ni = obj.trim_replicas(min_replicas=2, valid=False, invalid=True)
+        # I'd prefer not, but this is iRODS' behaviour. This test is just to emphasise
+        # this and detect if iRODS changes.
+        assert nv == 0
+        assert ni == 1
+        assert len(obj.replicas()) == 1
+        assert obj.replicas()[0].number == 0  # The fixture has replica 1 as invalid
+
+
 @m.describe("Query Metadata")
 class TestQueryMetadata(object):
     @m.describe("Query Collection namespace")
@@ -756,7 +825,11 @@ class TestQueryMetadata(object):
         )
 
 
+@m.describe("Test special paths (quotes, spaces)")
 class TestSpecialPath(object):
+    @m.describe("iRODS paths")
+    @m.context("When a Collection has spaces in its path")
+    @m.it("Behaves normally")
     def test_collection_space(self, special_paths):
         p = PurePath(special_paths, "a a")
         coll = Collection(p)
@@ -764,6 +837,8 @@ class TestSpecialPath(object):
         assert coll.path == p
         assert coll.path.name == "a a"
 
+    @m.context("When a Collection has quotes in its path")
+    @m.it("Behaves normally")
     def test_collection_quote(self, special_paths):
         p = PurePath(special_paths, 'b"b')
         coll = Collection(p)
@@ -771,18 +846,24 @@ class TestSpecialPath(object):
         assert coll.path == p
         assert coll.path.name == 'b"b'
 
+    @m.context("When a DataObject has spaces in its path")
+    @m.it("Behaves normally")
     def test_data_object_space(self, special_paths):
         p = PurePath(special_paths, "y y.txt")
         obj = DataObject(p)
         assert obj.exists()
         assert obj.name == "y y.txt"
 
+    @m.context("When a DataObject has quotes in its path")
+    @m.it("Behaves normally")
     def test_data_object_quote(self, special_paths):
         p = PurePath(special_paths, 'z".txt')
         obj = DataObject(p)
         assert obj.exists()
         assert obj.name == 'z".txt'
 
+    @m.context("When a Collection has quotes and spaced in the paths of its contents")
+    @m.it("Behaves normally")
     def test_collection_contents(self, special_paths):
         expected = [
             PurePath(special_paths, p).as_posix()

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -25,8 +25,6 @@ from pathlib import PurePath
 import pytest
 from pytest import mark as m
 
-import partisan
-
 from partisan import irods
 from partisan.exception import BatonError, RodsError
 from partisan.irods import (
@@ -152,16 +150,16 @@ class TestRodsPath(object):
     @m.context("When a collection path exists")
     @m.it("Is identified as a collection")
     def test_collection_path_type(self, simple_collection):
-        assert rods_path_type(simple_collection) == partisan.irods.Collection
+        assert rods_path_type(simple_collection) == Collection
         assert make_rods_item(simple_collection) == Collection(simple_collection)
-        assert Collection(simple_collection).rods_type == partisan.irods.Collection
+        assert Collection(simple_collection).rods_type == Collection
 
     @m.context("When a data object path exists")
     @m.it("Is identified as a data object")
     def test_data_object_path_type(self, simple_data_object):
-        assert rods_path_type(simple_data_object) == partisan.irods.DataObject
+        assert rods_path_type(simple_data_object) == DataObject
         assert make_rods_item(simple_data_object) == DataObject(simple_data_object)
-        assert DataObject(simple_data_object).rods_type == partisan.irods.DataObject
+        assert DataObject(simple_data_object).rods_type == DataObject
 
 
 @m.describe("Collection")


### PR DESCRIPTION
Add replica trimming methods to DataObject.
Add test support SQL and fixtures ot create data objects with invalid replicas.
Add iquest and itrim icommands.