### PR TITLE
Add avu method

### DIFF
--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1284,6 +1284,37 @@ class RodsItem(PathLike):
         """
         return self._exists(timeout=timeout, tries=tries)
 
+    def avu(self, attr: str, timeout=None, tries=1) -> AVU:
+        """Return an unique AVU from the item's metadata, given an attribute, or raise
+        an error.
+
+        Args:
+            attr: The attribute of the expected AVU.
+            timeout: Operation timeout in seconds.
+            tries: Number of times to try the operation.
+
+        Returns:
+
+        """
+        avus = [
+            avu
+            for avu in self.metadata(timeout=timeout, tries=tries)
+            if avu.attribute == attr
+        ]
+
+        if not avus:
+            raise ValueError(
+                f"Metadata of {self} did not contain any AVU with "
+                f"attribute '{attr}'"
+            )
+        if len(avus) > 1:
+            raise ValueError(
+                f"Metadata of '{self}' contained more than one AVU with "
+                f"attribute '{attr}': {avus}"
+            )
+
+        return avus[0]
+
     def has_metadata(self, *avus: AVU, timeout=None, tries=1) -> bool:
         """Return True if all the argument AVUs are in the item's metadata.
 

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -418,6 +418,23 @@ class TestCollection:
             coll.remove_metadata(avu1, avu2) == 0
         ), "removing collection metadata is idempotent"
 
+    @m.it("Can be searched for an AVU with an unique attribute")
+    def test_avu_collection(self, simple_collection):
+        coll = Collection(simple_collection)
+        avu = AVU("abcde", "12345")
+
+        with pytest.raises(ValueError, match="did not contain any AVU with attribute"):
+            coll.avu("abcde")
+        coll.add_metadata(avu)
+
+        assert coll.avu("abcde") == avu
+
+        coll.add_metadata(AVU("abcde", "67890"))
+        with pytest.raises(
+            ValueError, match="contained more than one AVU with attribute"
+        ):
+            coll.avu("abcde")
+
     @m.it("Can be found by its metadata")
     def test_meta_query_collection(self, simple_collection):
         coll = Collection(simple_collection)
@@ -665,6 +682,23 @@ class TestDataObject:
         assert (
             obj.remove_metadata(avu1, avu2) == 0
         ), "removing data object metadata is idempotent"
+
+    @m.it("Can be searched for an AVU with an unique attribute")
+    def test_avu_collection(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+        avu = AVU("abcde", "12345")
+
+        with pytest.raises(ValueError, match="did not contain any AVU with attribute"):
+            obj.avu("abcde")
+        obj.add_metadata(avu)
+
+        assert obj.avu("abcde") == avu
+
+        obj.add_metadata(AVU("abcde", "67890"))
+        with pytest.raises(
+            ValueError, match="contained more than one AVU with attribute"
+        ):
+            obj.avu("abcde")
 
     @m.it("Can have metadata replaced")
     def test_repl_meta_data_object(self, simple_data_object):


### PR DESCRIPTION
This is a convenience method which allows a single AVU with a known attribute to be returned.