### PR TITLE
Add iRODS 4.2.12 to CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -28,6 +28,10 @@ jobs:
             client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.11:latest"
             server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.11:latest"
             experimental: false
+          - irods: "4.2.12"
+            client_image: "ghcr.io/wtsi-npg/ub-18.04-irods-clients-4.2.12:latest"
+            server_image: "ghcr.io/wtsi-npg/ub-18.04-irods-4.2.12:latest"
+            experimental: true
 
     services:
       irods-server:


### PR DESCRIPTION
Marked as "experimental" because of a breaking change to iquest's exit codes.