### PR TITLE
Fix incorrect recursive behaviour of add/remove/supersede_permissions

### DIFF
--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1486,6 +1486,9 @@ class RodsItem(PathLike):
         controls added. If some argument access controls are already present,
         those arguments will be ignored.
 
+        This method handles only the permissions of this RodsItem. See the Collection
+        class for methods handling recursive operations.
+
         Args:
             *acs: Access controls.
             timeout: Operation timeout in seconds.
@@ -1516,6 +1519,9 @@ class RodsItem(PathLike):
         """Remove access controls from the item. Return the number of access
         controls removed. If some argument access controls are not present, those
         arguments will be ignored.
+
+        This method handles only the permissions of this RodsItem. See the Collection
+        class for methods handling recursive operations.
 
         Args:
             *acs: Access controls.
@@ -1551,6 +1557,9 @@ class RodsItem(PathLike):
         specified access controls. Return the numbers of access controls
         removed and added.
 
+        This method handles only the permissions of this RodsItem. See the Collection
+        class for methods handling recursive operations.
+
         Args:
             *acs: Access controls.
             timeout: Operation timeout in seconds.
@@ -1563,8 +1572,6 @@ class RodsItem(PathLike):
 
         to_remove = sorted(set(current).difference(acs))
         if to_remove:
-            # If recurse is true, we want to do this update, even if the target path
-            # has the required ACL because child paths may not have the ACL.
             log.debug("Removing from ACL", path=self, ac=to_remove)
 
             # In iRODS we "remove" permissions by setting them to NULL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,24 @@ def annotated_collection(simple_collection):
 
 
 @pytest.fixture(scope="function")
+def full_collection(tmp_path):
+    """A fixture providing a collection with some contents"""
+    root_path = PurePath("/testZone/home/irods/test")
+    rods_path = add_rods_path(root_path, tmp_path)
+
+    iput("./tests/data/recursive/", rods_path, recurse=True)
+    coll_path = rods_path / "recursive"
+
+    try:
+        add_test_groups()
+
+        yield coll_path
+    finally:
+        remove_test_groups()
+        irm(root_path, force=True, recurse=True)
+
+
+@pytest.fixture(scope="function")
 def simple_data_object(tmp_path):
     """A fixture providing a collection containing a single data object containing
     UTF-8 data."""

--- a/tests/data/recursive/level1/level2/leaf1.txt
+++ b/tests/data/recursive/level1/level2/leaf1.txt
@@ -1,0 +1,1 @@
+e276ebe6-012e-11ee-b52e-c3459e3defec

--- a/tests/data/recursive/level1/level2/leaf2.txt
+++ b/tests/data/recursive/level1/level2/leaf2.txt
@@ -1,0 +1,1 @@
+d1dc40b0-012e-11ee-8774-af1e5dcfdab1


### PR DESCRIPTION
For collections, ensure that full recursion is carried out when changing permisssions, rather than just inspected/updating the root collection path.

Avoid modifiying the arguments passed to the permissions methods, which had the effect of mutating the object's ACL.

These changes were made by overriding the relevent RodsItem methods specifically for Collections. The RodsItem methods now deal with the non-recursive cases (for both Collections and DataObjects).