### PR TITLE
Revert "Add namespace keyword to avu method"

### DIFF
--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -916,7 +916,7 @@ class AVU(object):
 
     @property
     def attribute(self):
-        """The attribute, including namespace, if any. The namespace and attribute are
+        """The attribute, including namespace, if any. The namespace an attribute are
         separated by AVU.SEPARATOR."""
         if self._namespace:
             return f"{self._namespace}{AVU.SEPARATOR}{self._attribute}"
@@ -1314,41 +1314,33 @@ class RodsItem(PathLike):
         """
         return self._exists(timeout=timeout, tries=tries)
 
-    def avu(self, attr: Any, namespace=None, timeout=None, tries=1) -> AVU:
+    def avu(self, attr: str, timeout=None, tries=1) -> AVU:
         """Return an unique AVU from the item's metadata, given an attribute, or raise
         an error.
 
         Args:
-            attr: The attribute of the expected AVU. This must be the bare attribute
-               string, without any namespace.
-            namespace: The namespace of the expected AVU. Optional.
+            attr: The attribute of the expected AVU.
             timeout: Operation timeout in seconds.
             tries: Number of times to try the operation.
 
         Returns:
 
         """
-        # Allows convenient use of args that have string representations which are AVU attributes
-        attr = str(attr)
-
-        # Construct a dummy AVU as a convenience to get namespaced attribute string
-        ns_attr = AVU(attr, "dummy", namespace=namespace).attribute
         avus = [
             avu
             for avu in self.metadata(timeout=timeout, tries=tries)
-            if avu.attribute == ns_attr
+            if avu.attribute == attr
         ]
 
-        ns_msg = f" in namespace '{namespace}'" if namespace else ""
         if not avus:
             raise ValueError(
                 f"Metadata of {self} did not contain any AVU with "
-                f"attribute '{attr}'{ns_msg}"
+                f"attribute '{attr}'"
             )
         if len(avus) > 1:
             raise ValueError(
                 f"Metadata of '{self}' contained more than one AVU with "
-                f"attribute '{attr}'{ns_msg}: {avus}"
+                f"attribute '{attr}': {avus}"
             )
 
         return avus[0]
@@ -1366,9 +1358,7 @@ class RodsItem(PathLike):
         return set(avus).issubset(self.metadata(timeout=timeout, tries=tries))
 
     def has_metadata_attrs(self, *attrs: str, timeout=None, tries=1) -> bool:
-        """Return True if all the argument attributes are in the item's metadata. The
-        caller must set the namespace(s) appropriately on the attrs before calling this
-        methods as each attribute many have different (or no) namespace.
+        """Return True if all the argument attributes are in the item's metadata.
 
         Args:
             *attrs: One or more attributes to test.

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -421,53 +421,19 @@ class TestCollection:
     @m.it("Can be searched for an AVU with an unique attribute")
     def test_avu_collection(self, simple_collection):
         coll = Collection(simple_collection)
-        attr = "abcde"
-        avu = AVU(attr, "12345")
+        avu = AVU("abcde", "12345")
 
         with pytest.raises(ValueError, match="did not contain any AVU with attribute"):
-            coll.avu(attr)
+            coll.avu("abcde")
         coll.add_metadata(avu)
 
-        assert coll.avu(attr) == avu
+        assert coll.avu("abcde") == avu
 
-        coll.add_metadata(AVU(attr, "67890"))
+        coll.add_metadata(AVU("abcde", "67890"))
         with pytest.raises(
             ValueError, match="contained more than one AVU with attribute"
         ):
-            coll.avu(attr)
-
-    @m.it("Can be searched for an AVU with an unique namespaced attribute")
-    def test_avu_collection_ns(self, simple_collection):
-        coll = Collection(simple_collection)
-        attr = "abcde"
-        ns = "test"
-        avu = AVU(attr, "12345", namespace=ns)
-
-        with pytest.raises(
-            ValueError, match=f"did not contain any AVU with attribute '{attr}'"
-        ):
-            coll.avu(attr)
-        with pytest.raises(
-            ValueError,
-            match=f"did not contain any AVU with attribute '{attr}' in namespace '{ns}'",
-        ):
-            coll.avu(attr, namespace=ns)
-
-        coll.add_metadata(avu)
-
-        with pytest.raises(
-            ValueError, match=f"did not contain any AVU with attribute '{attr}'"
-        ):
-            coll.avu(attr)
-
-        assert coll.avu(attr, namespace=ns) == avu
-
-        other_ns = "other"
-        with pytest.raises(
-            ValueError,
-            match=f"did not contain any AVU with attribute '{attr}' in namespace '{other_ns}'",
-        ):
-            coll.avu(attr, namespace=other_ns)
+            coll.avu("abcde")
 
     @m.it("Can be found by its metadata")
     def test_meta_query_collection(self, simple_collection):
@@ -876,55 +842,21 @@ class TestDataObject:
         ), "removing data object metadata is idempotent"
 
     @m.it("Can be searched for an AVU with an unique attribute")
-    def test_avu_data_object(self, simple_data_object):
+    def test_avu_collection(self, simple_data_object):
         obj = DataObject(simple_data_object)
-        attr = "abcde"
-        avu = AVU(attr, "12345")
+        avu = AVU("abcde", "12345")
 
         with pytest.raises(ValueError, match="did not contain any AVU with attribute"):
-            obj.avu(attr)
+            obj.avu("abcde")
         obj.add_metadata(avu)
 
-        assert obj.avu(attr) == avu
+        assert obj.avu("abcde") == avu
 
-        obj.add_metadata(AVU(attr, "67890"))
+        obj.add_metadata(AVU("abcde", "67890"))
         with pytest.raises(
             ValueError, match="contained more than one AVU with attribute"
         ):
-            obj.avu(attr)
-
-    @m.it("Can be searched for an AVU with an unique namespaced attribute")
-    def test_avu_data_object_ns(self, simple_data_object):
-        obj = DataObject(simple_data_object)
-        attr = "abcde"
-        ns = "test"
-        avu = AVU(attr, "12345", namespace=ns)
-
-        with pytest.raises(
-            ValueError, match=f"did not contain any AVU with attribute '{attr}'"
-        ):
-            obj.avu(attr)
-        with pytest.raises(
-            ValueError,
-            match=f"did not contain any AVU with attribute '{attr}' in namespace '{ns}'",
-        ):
-            obj.avu(attr, namespace=ns)
-
-        obj.add_metadata(avu)
-
-        with pytest.raises(
-            ValueError, match=f"did not contain any AVU with attribute '{attr}'"
-        ):
-            obj.avu(attr)
-
-        assert obj.avu(attr, namespace=ns) == avu
-
-        other_ns = "other"
-        with pytest.raises(
-            ValueError,
-            match=f"did not contain any AVU with attribute '{attr}' in namespace '{other_ns}'",
-        ):
-            obj.avu(attr, namespace=other_ns)
+            obj.avu("abcde")
 
     @m.it("Can have metadata superseded")
     def test_supersede_meta_data_object(self, simple_data_object):


### PR DESCRIPTION
Reverts wtsi-npg/partisan#108

I've realised that is probably best that the code here is _not_ managing namespaces explicitly. That can be left to the various `Enum`s of attributes to handle. All we need to change is to make the `avu` convert its `attribute` argument into a string. That way any namespace will be included.