### PR TITLE
Add attribute argument stringification

### DIFF
--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1352,25 +1352,26 @@ class RodsItem(PathLike):
             A single AVU with the specified attribute.
         """
         attr = str(attribute)
-        # avus = [
-        #     avu
-        #     for avu in self.metadata(timeout=timeout, tries=tries)
-        #     if avu.attribute == attr
-        # ]
-        avus = []
-        for avu in self.metadata(timeout=timeout, tries=tries):
-            log.debug(
-                "Checking for AVU",
-                path=self,
-                target=attr,
-                avu_attr=avu.attribute,
-                avu_ns=avu.namespace,
-                avu_wo_ns=avu.without_namespace)
-            if avu.attribute == attr:
-                log.debug("Found AVU", present=avu)
-                avus.append(avu)
-            else:
-                log.debug("Not found AVU", absent=avu)
+        avus = [
+            avu
+            for avu in self.metadata(timeout=timeout, tries=tries)
+            if avu.attribute == attr
+        ]
+        # avus = []
+        # for avu in self.metadata(timeout=timeout, tries=tries):
+        #     log.debug(
+        #         "Checking for AVU",
+        #         path=self,
+        #         target=attr,
+        #         avu_attr=avu.attribute,
+        #         avu_ns=avu.namespace,
+        #         avu_wo_ns=avu.without_namespace,
+        #     )
+        #     if avu.attribute == attr:
+        #         log.debug("Found AVU", present=avu)
+        #         avus.append(avu)
+        #     else:
+        #         log.debug("Not found AVU", absent=avu)
 
         if not avus:
             raise ValueError(

--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1352,11 +1352,25 @@ class RodsItem(PathLike):
             A single AVU with the specified attribute.
         """
         attr = str(attribute)
-        avus = [
-            avu
-            for avu in self.metadata(timeout=timeout, tries=tries)
-            if avu.attribute == attr
-        ]
+        # avus = [
+        #     avu
+        #     for avu in self.metadata(timeout=timeout, tries=tries)
+        #     if avu.attribute == attr
+        # ]
+        avus = []
+        for avu in self.metadata(timeout=timeout, tries=tries):
+            log.debug(
+                "Checking for AVU",
+                path=self,
+                target=attr,
+                avu_attr=avu.attribute,
+                avu_ns=avu.namespace,
+                avu_wo_ns=avu.without_namespace)
+            if avu.attribute == attr:
+                log.debug("Found AVU", present=avu)
+                avus.append(avu)
+            else:
+                log.debug("Not found AVU", absent=avu)
 
         if not avus:
             raise ValueError(


### PR DESCRIPTION
Where `AVU` attributes are passed as arguments, allow them to be non-string types which are then automatically stringified. This makes calling them less verbose.

Fix an incorrect test in `__lt__` of `AC` exposed while making this change.