### PR TITLE
Use extend instead of append for adding to list when getting acl list

### DIFF
--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1687,7 +1687,7 @@ class RodsItem(PathLike):
                 if own and read:
                     acs.difference_update(read)
 
-            acl.append(*acs)
+            acl.extend(acs)
 
         return sorted(acl)
 


### PR DESCRIPTION
`TypeError: list.append() takes exactly one argument (2 given)` when trying to supersede a read or write AC with an own AC on a collection.