### PR TITLE
Add attribute argument stringification

### DIFF
--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -754,7 +754,7 @@ class AC(object):
                 "zone= keyword argument to set a zone"
             )
 
-        if zone:
+        if zone is not None:
             if zone.find(AC.SEPARATOR) >= 0:
                 raise ValueError(f"Zone '{zone}' contained '{AC.SEPARATOR}'")
         self.user = user
@@ -784,7 +784,7 @@ class AC(object):
             return True
 
         if self.zone is None and other.zone is not None:
-            return True
+            return False
 
         if self.zone is not None and other.zone is not None:
             if self.zone < other.zone:
@@ -822,18 +822,43 @@ class AVU(object):
     """The attribute history suffix"""
 
     def __init__(self, attribute: Any, value: Any, units=None, namespace=None):
-        if namespace:
-            if namespace.find(AVU.SEPARATOR) >= 0:
-                raise ValueError(
-                    f"AVU namespace '{namespace}' contained '{AVU.SEPARATOR}'"
-                )
+        """Create a new AVU instance.
+
+        Args:
+            attribute: The attribute to use. If this is not a string, the string
+               representation of this argument becomes the attribute.
+            value: The value to use. If this is not a string, the string
+               representation of this argument becomes the value.
+            units: The units to use. Optional, defaults to None.
+            namespace: The namespace (prefix) to be used for the attribute. Optional,
+               but if supplied, must be the same as any existing namespace on the
+               attribute string.
+        """
         if attribute is None:
             raise ValueError("AVU attribute may not be None")
         if value is None:
             raise ValueError("AVU value may not be None")
+        if namespace is None:
+            namespace = ""
+
+        if namespace.find(AVU.SEPARATOR) >= 0:
+            raise ValueError(
+                f"AVU namespace contained a separator '{AVU.SEPARATOR}': '{namespace}'"
+            )
+
+        attr = str(attribute)
+        if attr.find(AVU.SEPARATOR) >= 0:
+            ns, at = attr.split(AVU.SEPARATOR, maxsplit=1)
+            if namespace and ns != namespace:
+                raise ValueError(
+                    f"AVU attribute namespace '{ns}' did not match "
+                    f"the declared namespace '{namespace}' for "
+                    f"attribute '{attr}', value '{value}'"
+                )
+            namespace, attr = ns, at
 
         self._namespace = namespace
-        self._attribute = str(attribute)
+        self._attribute = attr
         self._value = str(value)
         self._units = units
 
@@ -968,12 +993,13 @@ class AVU(object):
         )
 
     def __lt__(self, other):
-        if self.namespace is not None and other.namespace is None:
+        if self.namespace and not other.namespace:
             return True
-        if self.namespace is None and other.namespace is not None:
+
+        if not self.namespace and other.namespace:
             return False
 
-        if self.namespace is not None and other.namespace is not None:
+        if self.namespace and other.namespace:
             if self.namespace < other.namespace:
                 return True
 
@@ -1314,18 +1340,20 @@ class RodsItem(PathLike):
         """
         return self._exists(timeout=timeout, tries=tries)
 
-    def avu(self, attr: str, timeout=None, tries=1) -> AVU:
+    def avu(self, attribute: Any, timeout=None, tries=1) -> AVU:
         """Return an unique AVU from the item's metadata, given an attribute, or raise
         an error.
 
         Args:
-            attr: The attribute of the expected AVU.
+            attribute: The attribute of the expected AVU. If this is not a string,
+               the string representation of this argument is used.
             timeout: Operation timeout in seconds.
             tries: Number of times to try the operation.
 
         Returns:
-
+            A single AVU with the specified attribute.
         """
+        attr = str(attribute)
         avus = [
             avu
             for avu in self.metadata(timeout=timeout, tries=tries)
@@ -1357,17 +1385,19 @@ class RodsItem(PathLike):
         """
         return set(avus).issubset(self.metadata(timeout=timeout, tries=tries))
 
-    def has_metadata_attrs(self, *attrs: str, timeout=None, tries=1) -> bool:
+    def has_metadata_attrs(self, *attributes: Any, timeout=None, tries=1) -> bool:
         """Return True if all the argument attributes are in the item's metadata.
 
         Args:
-            *attrs: One or more attributes to test.
+            *attributes: One or more attributes to test. If any of these are not strings,
+               their string representations is used.
             timeout: Operation timeout in seconds.
             tries: Number of times to try the operation.
 
         Returns: True if every attribute is present in at least one AVU.
         """
         collated = self.collated_metadata(timeout=timeout, tries=tries)
+        attrs = [str(a) for a in attributes]
         return set(attrs).issubset(collated.keys())
 
     @rods_type_check
@@ -1593,11 +1623,12 @@ class RodsItem(PathLike):
         return len(to_remove), len(to_add)
 
     @rods_type_check
-    def metadata(self, attr: str = None, timeout=None, tries=1) -> List[AVU]:
+    def metadata(self, attribute: Any = None, timeout=None, tries=1) -> List[AVU]:
         """Return the item's metadata.
 
         Args:
-            attr: Return only AVUs having this attribute.
+            attribute: Return only AVUs having this attribute. If this is not a string,
+               the string representation of this argument is used.
             timeout: Operation timeout in seconds.
             tries: Number of times to try the operation.
 
@@ -1608,7 +1639,8 @@ class RodsItem(PathLike):
             raise BatonError(f"{Baton.AVUS} key missing from {item}")
 
         avus = item[Baton.AVUS]
-        if attr is not None:
+        if attribute is not None:
+            attr = str(attribute)
             avus = [avu for avu in avus if avu.attribute == attr]
 
         return sorted(avus)


### PR DESCRIPTION
Where AVU attributes are passed as arguments, allow them to be non-string types which are then automatically stringified. This makes calling them less verbose.

Fix an incorrect test in __lt__ of AC exposed while making this change.