### PR TITLE
Use structlog.get_logger() with no arguments

### DIFF
--- a/src/partisan/cli.py
+++ b/src/partisan/cli.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2022 Genome Research Ltd. All rights reserved.
+# Copyright © 2022, 2023 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ import partisan
 from partisan.irods import Collection, DataObject, make_rods_item, rods_path_type
 
 logging.basicConfig(level=logging.ERROR)
-log = get_logger(__name__)
+log = get_logger()
 
 
 class RodsPathType(ParamType):

--- a/src/partisan/icommands.py
+++ b/src/partisan/icommands.py
@@ -27,7 +27,7 @@ from structlog import get_logger
 
 from partisan.exception import RodsError
 
-log = get_logger(__name__)
+log = get_logger()
 
 
 def mkgroup(name: str):

--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -49,7 +49,7 @@ from partisan.exception import (
 )
 from partisan.icommands import iquest, itrim, iuserinfo
 
-log = get_logger(__name__)
+log = get_logger()
 
 """This module provides a basic API for accessing iRODS using the native
 iRODS client 'baton' (https://github.com/wtsi-npg/baton).
@@ -268,6 +268,7 @@ class Baton:
             timeout=timeout,
             tries=tries,
         )
+
         checksum = result[Baton.CHECKSUM]
         return checksum
 


### PR DESCRIPTION
This allows easier default configuration (structlog still reports the module where the logs originate).