### PR TITLE
Add baton JSON serialization/deserialization for Python applications

### DIFF
--- a/src/partisan/icommands.py
+++ b/src/partisan/icommands.py
@@ -25,7 +25,6 @@ import shlex
 import subprocess
 from io import StringIO
 from pathlib import Path, PurePath
-from typing import List, Union
 
 from structlog import get_logger
 
@@ -69,7 +68,7 @@ def iuserinfo(name: str = None) -> str:
     raise RodsError(completed.stderr.decode("utf-8").strip())
 
 
-def imkdir(remote_path: Union[PurePath, str], make_parents=True):
+def imkdir(remote_path: PurePath | str, make_parents=True):
     cmd = ["imkdir"]
     if make_parents:
         cmd.append("-p")
@@ -122,8 +121,8 @@ def iinit():
 
 
 def iget(
-    remote_path: Union[PurePath, str],
-    local_path: Union[PurePath, str],
+    remote_path: PurePath | str,
+    local_path: PurePath | str,
     force=False,
     verify_checksum=True,
     recurse=False,
@@ -142,8 +141,8 @@ def iget(
 
 
 def iput(
-    local_path: Union[PurePath, str],
-    remote_path: Union[PurePath, str],
+    local_path: PurePath | str,
+    remote_path: PurePath | str,
     force=False,
     verify_checksum=True,
     recurse=False,
@@ -161,7 +160,7 @@ def iput(
     _run(cmd)
 
 
-def irm(remote_path: Union[PurePath, str], force=False, recurse=False):
+def irm(remote_path: PurePath | str, force=False, recurse=False):
     cmd = ["irm"]
     if force:
         cmd.append("-f")
@@ -181,14 +180,14 @@ def irm(remote_path: Union[PurePath, str], force=False, recurse=False):
             raise
 
 
-def itrim(remote_path: Union[PurePath, str], replica_num: int, min_replicas=2):
+def itrim(remote_path: PurePath | str, replica_num: int, min_replicas=2):
     cmd = ["itrim", "-n", f"{replica_num}", "-N", f"{min_replicas}", remote_path]
     _run(cmd)
 
 
 def icp(
-    from_path: Union[PurePath, str],
-    to_path: Union[PurePath, str],
+    from_path: PurePath | str,
+    to_path: PurePath | str,
     force=False,
     verify_checksum=True,
     recurse=False,
@@ -257,7 +256,7 @@ def remove_specific_sql(alias):
         _run(cmd)
 
 
-def _run(cmd: List[str]):
+def _run(cmd: list[str]):
     log.debug("Running command", cmd=cmd)
 
     completed = subprocess.run(cmd, capture_output=True)

--- a/src/partisan/icommands.py
+++ b/src/partisan/icommands.py
@@ -43,6 +43,16 @@ def rmgroup(name: str):
     _run(cmd)
 
 
+def mkuser(name: str):
+    cmd = ["iadmin", "mkuser", name, "rodsuser"]
+    _run(cmd)
+
+
+def rmuser(name: str):
+    cmd = ["iadmin", "rmuser", name]
+    _run(cmd)
+
+
 def group_exists(name: str) -> bool:
     info = iuserinfo(name)
     for line in info.splitlines():
@@ -52,6 +62,18 @@ def group_exists(name: str) -> bool:
             return True
 
     log.debug("Group check", exists=False, name=name)
+    return False
+
+
+def user_exists(name: str) -> bool:
+    info = iuserinfo(name)
+    for line in info.splitlines():
+        log.debug("Checking line", line=line)
+        if re.match(r"type:\s+(rodsuser|groupadmin|rodsadmin)", line):
+            log.debug("User check", exists=True, name=name)
+            return True
+
+    log.debug("User check", exists=False, name=name)
     return False
 
 

--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1383,7 +1383,7 @@ def rods_path_type(
 ) -> Type[RodsItem] | None:
     """Return a Python type representing the kind of iRODS path supplied.
 
-    e.g. Collection for and iRODS collection, DataObject for an iRODS data object.
+    e.g. Collection for an iRODS collection, DataObject for an iRODS data object.
     The value returned is what the iRODS server recognises the path as. If the
     remote path does not exist, returns None.
 

--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -41,13 +41,9 @@ from threading import Thread
 from typing import (
     Annotated,
     Any,
-    Dict,
     Iterable,
-    List,
     Optional,
-    Tuple,
     Type,
-    Union,
 )
 
 import dateutil.parser
@@ -198,7 +194,7 @@ class Baton:
 
     def list(
         self,
-        item: Dict,
+        item: dict,
         acl=False,
         avu=False,
         checksum=False,
@@ -208,7 +204,7 @@ class Baton:
         timestamp=False,
         timeout=None,
         tries=1,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """Lists i.e. reports on items in iRODS.
 
         Args:
@@ -262,7 +258,7 @@ class Baton:
         """Perform remote checksum operations.
 
         Args:
-            item: A dictionary representing the item When serialized as JSON,
+            item: A dictionary representing the item. When serialized as JSON,
                 this must be suitable input for baton-do.
             calculate_checksum: Ask iRODS to calculate the checksum, if there is no
                 remote checksum currently.
@@ -288,11 +284,11 @@ class Baton:
         checksum = result[Baton.CHECKSUM]
         return checksum
 
-    def add_metadata(self, item: Dict, timeout=None, tries=1):
+    def add_metadata(self, item: dict, timeout=None, tries=1):
         """Add metadata to an item in iRODS.
 
         Args:
-            item: A dictionary representing the item When serialized as JSON,
+            item: A dictionary representing the item. When serialized as JSON,
             this must be suitable input for baton-do.
             timeout: Operation timeout.
             tries: Number of times to try the operation.
@@ -301,7 +297,7 @@ class Baton:
             Baton.METAMOD, {Baton.OP: Baton.ADD}, item, timeout=timeout, tries=tries
         )
 
-    def remove_metadata(self, item: Dict, timeout=None, tries=1):
+    def remove_metadata(self, item: dict, timeout=None, tries=1):
         """Remove metadata from an item in iRODS.
 
         Args:
@@ -316,13 +312,13 @@ class Baton:
 
     def query_metadata(
         self,
-        avus: List[AVU],
+        avus: list[AVU],
         zone=None,
         collection=False,
         data_object=False,
         timeout=None,
         tries=1,
-    ) -> Dict:
+    ) -> dict:
         """Query metadata in iRODS.
 
         Args:
@@ -347,7 +343,7 @@ class Baton:
 
         return self._execute(Baton.METAQUERY, args, item, timeout=timeout, tries=tries)
 
-    def set_permission(self, item: Dict, recurse=False, timeout=None, tries=1):
+    def set_permission(self, item: dict, recurse=False, timeout=None, tries=1):
         """Set access permissions on a data object or collection.
 
         Args:
@@ -363,7 +359,7 @@ class Baton:
 
     def get(
         self,
-        item: Dict,
+        item: dict,
         local_path: Path,
         verify_checksum=False,
         force=True,
@@ -410,7 +406,7 @@ class Baton:
         )
         return local_path.stat().st_size
 
-    def read(self, item: Dict, timeout=None, tries=1) -> str:
+    def read(self, item: dict, timeout=None, tries=1) -> str:
         """Read the contents of a data object as a string.
 
         Args:
@@ -430,7 +426,7 @@ class Baton:
 
     def put(
         self,
-        item: Dict,
+        item: dict,
         local_path: Path,
         calculate_checksum=False,
         verify_checksum=False,
@@ -465,7 +461,7 @@ class Baton:
             tries=tries,
         )
 
-    def create_collection(self, item: Dict, parents=False, timeout=None, tries=1):
+    def create_collection(self, item: dict, parents=False, timeout=None, tries=1):
         """Create a new collection.
 
         Args:
@@ -480,8 +476,8 @@ class Baton:
         )
 
     def _execute(
-        self, operation: str, args: Dict, item: Dict, timeout=None, tries=1
-    ) -> Dict:
+        self, operation: str, args: dict, item: dict, timeout=None, tries=1
+    ) -> dict:
         if not self.is_running():
             log.debug(f"{Baton.CLIENT} is not running ... starting")
             self.start()
@@ -523,7 +519,7 @@ class Baton:
         return self._unwrap(response)
 
     @staticmethod
-    def _wrap(operation: str, args: Dict, item: Dict) -> Dict:
+    def _wrap(operation: str, args: dict, item: dict) -> dict:
         return {
             Baton.OP: operation,
             Baton.ARGS: args,
@@ -531,7 +527,7 @@ class Baton:
         }
 
     @staticmethod
-    def _unwrap(envelope: Dict) -> Dict:
+    def _unwrap(envelope: dict) -> dict:
         # If there is an error report from the iRODS server in the envelope, we need to
         # raise a RodsError
         if Baton.ERR in envelope:
@@ -560,7 +556,7 @@ class Baton:
             "Operation result value was empty", envelope=envelope
         )
 
-    def _send(self, envelope: Dict) -> Dict:
+    def _send(self, envelope: dict) -> dict:
         encoded = json.dumps(envelope, cls=BatonJSONEncoder)
         log.debug("Sending", msg=encoded)
 
@@ -712,7 +708,7 @@ def query_metadata(
     timeout=None,
     tries=1,
     pool=default_pool,
-) -> List[Union[DataObject, Collection]]:
+) -> list[Collection | DataObject]:
     """
     Query all metadata in iRODS (i.e. both on collections and data objects)
 
@@ -725,7 +721,7 @@ def query_metadata(
         tries: Number of times to try the operation.
         pool: Client pool to use. If omitted, the default pool is used.
 
-    Returns: List[Union[DataObject, Collection]]
+    Returns: List[Collection | DataObject]
     """
     with client(pool) as c:
         result = c.query_metadata(
@@ -918,7 +914,7 @@ class AVU(object):
         self._operator = operator
 
     @classmethod
-    def collate(cls, *avus: AVU) -> Dict[str : List[AVU]]:
+    def collate(cls, *avus: AVU) -> dict[str : list[AVU]]:
         """Collates AVUs by attribute (including namespace, if any) and
         returns a dict mapping the attribute to a list of AVUs with that
         attribute.
@@ -951,7 +947,7 @@ class AVU(object):
         Returns: AVU
         """
         if history_date is None:
-            history_date = datetime.utcnow()
+            history_date = datetime.now(timezone.utc)
         date = format_timestamp(history_date)
 
         # Check that the AVUs have the same namespace and attribute and that
@@ -1206,10 +1202,10 @@ class User(object):
     and their zone.
     """
 
-    def __init__(self, name: str, id: str, type: str, zone: str):
+    def __init__(self, name: str, user_id: str, user_type: str, zone: str):
         self.name = name
-        self.id = id
-        self.type = type
+        self.id = user_id
+        self.type = user_type
         self.zone = zone
 
     def is_rodsadmin(self):
@@ -1333,7 +1329,7 @@ def rods_type_check(method):
 
 
 def rods_path_exists(
-    path: Union[PurePath, str], timeout=None, tries=1, pool=default_pool
+    path: PurePath | str, timeout=None, tries=1, pool=default_pool
 ) -> bool:
     """Return true if the specified path is a collection or data object in iRODS.
 
@@ -1350,7 +1346,7 @@ def rods_path_exists(
 
 
 def rods_path_type(
-    path: Union[PurePath, str], timeout=None, tries=1, pool=default_pool
+    path: PurePath | str, timeout=None, tries=1, pool=default_pool
 ) -> Optional[Type[RodsItem]]:
     """Return a Python type representing the kind of iRODS path supplied,
     e.g. Collection for and iRODS collection, DataObject for an iRODS data object. If
@@ -1363,7 +1359,7 @@ def rods_path_type(
         pool: A baton client pool. Optional.
 
     Returns:
-        Union[DataObject, Collection], or None.
+        Collection | DataObject, or None.
     """
     try:
         with client(pool) as c:
@@ -1374,10 +1370,10 @@ def rods_path_type(
                     return Collection
                 case [item]:
                     raise ValueError(f"Failed to recognised client response {item}")
-    except RodsError as re:
-        if re.code == -310000:  # iRODS error code for path not found
+    except RodsError as e:
+        if e.code == -310000:  # iRODS error code for path not found
             return None
-        raise re
+        raise e
 
 
 def format_timestamp(ts: datetime) -> str:
@@ -1390,9 +1386,7 @@ def format_timestamp(ts: datetime) -> str:
     return ts.isoformat(timespec="seconds")
 
 
-def make_rods_item(
-    path: Union[PurePath, str], pool=default_pool
-) -> Union[Collection, DataObject]:
+def make_rods_item(path: PurePath | str, pool=default_pool) -> Collection | DataObject:
     """A factory function for iRODS items.
 
     Args:
@@ -1410,15 +1404,22 @@ def make_rods_item(
 class RodsItem(PathLike):
     """A base class for iRODS path entities."""
 
-    def __init__(self, path: Union[PurePath, str], check_type=False, pool=default_pool):
+    def __init__(
+        self,
+        remote_path: PurePath | str,
+        local_path: Path | str = None,
+        check_type=False,
+        pool=default_pool,
+    ):
         """RodsItem constructor.
 
         Args:
-            path: A remote path.
+            remote_path: A remote path.
             check_type: Check the remote path type if True, defaults to False.
             pool: A baton client pool. Optional.
         """
-        self.path = PurePath(path)
+        self.path = PurePath(remote_path)
+        self.local_path = local_path
         self.check_type = check_type
         self.pool = pool
 
@@ -1427,8 +1428,8 @@ class RodsItem(PathLike):
     def _exists(self, timeout=None, tries=1) -> bool:
         try:
             self._list(timeout=timeout, tries=tries)
-        except RodsError as re:
-            if re.code == -310000:  # iRODS error code for path not found
+        except RodsError as e:
+            if e.code == -310000:  # iRODS error code for path not found
                 return False
         return True
 
@@ -1519,7 +1520,7 @@ class RodsItem(PathLike):
 
         if to_add:
             log.debug("Adding AVUs", path=self, avus=to_add)
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.AVUS] = to_add
             with client(self.pool) as c:
                 c.add_metadata(item, timeout=timeout, tries=tries)
@@ -1543,7 +1544,7 @@ class RodsItem(PathLike):
 
         if to_remove:
             log.debug("Removing AVUs", path=self, avus=to_remove)
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.AVUS] = to_remove
             with client(self.pool) as c:
                 c.remove_metadata(item, timeout=timeout, tries=tries)
@@ -1558,7 +1559,7 @@ class RodsItem(PathLike):
         history_date=None,
         timeout=None,
         tries=1,
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Remove AVUs from the item's metadata that share an attribute with
          any of the argument AVUs and add the argument AVUs to the item's
          metadata. Return the numbers of AVUs added and removed, including any
@@ -1600,7 +1601,7 @@ class RodsItem(PathLike):
 
         if to_remove:
             log.info("Removing AVUs", path=self, avus=to_remove)
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.AVUS] = to_remove
             with client(self.pool) as c:
                 c.remove_metadata(item, timeout=timeout, tries=tries)
@@ -1613,7 +1614,7 @@ class RodsItem(PathLike):
 
         if to_add:
             log.info("Adding AVUs", path=self, avus=to_add)
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.AVUS] = to_add
             with client(self.pool) as c:
                 c.add_metadata(item, timeout=timeout, tries=tries)
@@ -1642,7 +1643,7 @@ class RodsItem(PathLike):
 
         if to_add:
             log.info("Adding to ACL", path=self, ac=to_add)
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.ACCESS] = to_add
             with client(self.pool) as c:
                 c.set_permission(item, timeout=timeout, tries=tries)
@@ -1674,7 +1675,7 @@ class RodsItem(PathLike):
             # In iRODS we "remove" permissions by setting them to NULL
             to_null = [AC(ac.user, Permission.NULL, zone=ac.zone) for ac in to_remove]
 
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.ACCESS] = to_null
             with client(self.pool) as c:
                 c.set_permission(item, timeout=timeout, tries=tries)
@@ -1682,7 +1683,7 @@ class RodsItem(PathLike):
         return len(to_remove)
 
     @rods_type_check
-    def supersede_permissions(self, *acs: AC, timeout=None, tries=1) -> Tuple[int, int]:
+    def supersede_permissions(self, *acs: AC, timeout=None, tries=1) -> tuple[int, int]:
         """Remove all access controls from the item, replacing them with the
         specified access controls. Return the numbers of access controls
         removed and added.
@@ -1714,14 +1715,14 @@ class RodsItem(PathLike):
             # In iRODS we "remove" permissions by setting them to NULL
             to_null = [AC(ac.user, Permission.NULL, zone=ac.zone) for ac in to_remove]
 
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.ACCESS] = to_null
             with client(self.pool) as c:
                 c.set_permission(item, timeout=timeout, tries=tries)
 
         if to_add:
             log.info("Adding to ACL", path=self, ac=to_add)
-            item = self._to_dict()
+            item = self.to_dict()
             item[Baton.ACCESS] = to_add
             with client(self.pool) as c:
                 c.set_permission(item, timeout=timeout, tries=tries)
@@ -1729,7 +1730,7 @@ class RodsItem(PathLike):
         return len(to_remove), len(to_add)
 
     @rods_type_check
-    def metadata(self, attribute: Any = None, timeout=None, tries=1) -> List[AVU]:
+    def metadata(self, attribute: Any = None, timeout=None, tries=1) -> list[AVU]:
         """Return the item's metadata.
 
         Args:
@@ -1771,7 +1772,7 @@ class RodsItem(PathLike):
 
         return collated
 
-    def permissions(self, user_type: str = None, timeout=None, tries=1) -> List[AC]:
+    def permissions(self, user_type: str = None, timeout=None, tries=1) -> list[AC]:
         """Return the item's Access Control List (ACL). Synonym for acl().
 
         Args:
@@ -1784,7 +1785,7 @@ class RodsItem(PathLike):
         return self.acl(user_type=user_type, timeout=timeout, tries=tries)
 
     @rods_type_check
-    def acl(self, user_type: str = None, timeout=None, tries=1) -> List[AC]:
+    def acl(self, user_type: str = None, timeout=None, tries=1) -> list[AC]:
         """Return the item's Access Control List (ACL). Synonym for permissions().
 
         Args:
@@ -1861,17 +1862,39 @@ class RodsItem(PathLike):
         pass
 
     @abstractmethod
-    def get(self, local_path: Union[Path, str], **kwargs):
+    def get(self, local_path: Path | str, **kwargs):
         """Get the item from iRODS."""
         pass
 
     @abstractmethod
-    def put(self, local_path: Union[Path, str], **kwargs):
+    def put(self, local_path: Path | str, **kwargs):
         """Put the item into iRODS."""
         pass
 
     @abstractmethod
-    def _to_dict(self):
+    def to_dict(self) -> dict:
+        """Return a minimal dictionary representation of the item."""
+        pass
+
+    @abstractmethod
+    def to_json(self, **kwargs) -> str:
+        """Return a JSON representation of the item, including metadata and permissions.
+        Args:
+            **kwargs: See json.dumps() for options. All keywords except 'cls' are
+             passed through to a json.dumps() call by this method.
+        Returns:
+            A baton-format JSON string.
+        """
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_json(cls, json_str: str):
+        """Load the item from a JSON string.
+
+        Args:
+            json_str: A baton-format JSON string.
+        """
         pass
 
     @abstractmethod
@@ -1899,7 +1922,8 @@ class DataObject(RodsItem):
 
     def __init__(
         self,
-        remote_path: Union[PurePath, str],
+        remote_path: PurePath | str,
+        local_path: Path | str = None,
         check_type=True,
         pool=default_pool,
     ):
@@ -1910,8 +1934,21 @@ class DataObject(RodsItem):
             check_type: Check the remote path type if True, defaults to True.
             pool: A baton client pool. Optional.
         """
-        super().__init__(PurePath(remote_path).parent, check_type=check_type, pool=pool)
-        self.name = PurePath(remote_path).name
+        lp = Path(local_path) if local_path else None
+        rp = PurePath(remote_path)
+
+        super().__init__(
+            rp.parent,
+            local_path=lp.parent if lp else None,
+            check_type=check_type,
+            pool=pool,
+        )
+        self.name = rp.name
+
+        if lp is not None:
+            self.dir = lp.parent
+            self.file = lp.name
+
         self.versions = []
 
     @classmethod
@@ -2003,7 +2040,7 @@ class DataObject(RodsItem):
         Returns: A checksum
         """
         if calculate_checksum or recalculate_checksum or verify_checksum:
-            item = self._to_dict()
+            item = self.to_dict()
             with client(self.pool) as c:
                 return c.checksum(
                     item,
@@ -2087,7 +2124,7 @@ class DataObject(RodsItem):
         return min([r.modified for r in self.replicas(timeout=timeout, tries=tries)])
 
     @rods_type_check
-    def replicas(self, timeout=None, tries=1) -> List[Replica]:
+    def replicas(self, timeout=None, tries=1) -> list[Replica]:
         """Return the replicas of the data object.
 
         Args:
@@ -2144,9 +2181,7 @@ class DataObject(RodsItem):
         return replicas
 
     @rods_type_check
-    def get(
-        self, local_path: Union[Path, str], verify_checksum=False, timeout=None, tries=1
-    ):
+    def get(self, local_path: Path | str, verify_checksum=False, timeout=None, tries=1):
         """Get the data object from iRODS and save to a local file.
 
         Args:
@@ -2155,7 +2190,7 @@ class DataObject(RodsItem):
             timeout: Operation timeout in seconds.
             tries: Number of times to try the operation.
         """
-        item = self._to_dict()
+        item = self.to_dict()
         with client(self.pool) as c:
             return c.get(
                 item,
@@ -2167,7 +2202,7 @@ class DataObject(RodsItem):
 
     def put(
         self,
-        local_path: Union[Path, str],
+        local_path: Path | str,
         calculate_checksum=False,
         verify_checksum=False,
         local_checksum=None,
@@ -2308,7 +2343,7 @@ class DataObject(RodsItem):
 
         Returns: str
         """
-        item = self._to_dict()
+        item = self.to_dict()
         with client(self.pool) as c:
             return c.read(item, timeout=timeout, tries=tries)
 
@@ -2394,16 +2429,30 @@ class DataObject(RodsItem):
 
         return chk != DataObject.EMPTY_FILE_CHECKSUM
 
+    def to_dict(self) -> dict:
+        return {Baton.COLL: self.path.as_posix(), Baton.OBJ: self.name}
+
+    def to_json(self, **kwargs) -> str:
+        return json.dumps(self, cls=BatonJSONEncoder, **kwargs)
+
+    @classmethod
+    def from_json(cls, s: str):
+        o = json.loads(s, cls=BatonJSONDecoder)
+        if isinstance(o, DataObject):
+            return o
+
+        raise ValueError(f"Expected a DataObject, got {type(o)}")
+
     def _put(
         self,
-        local_path: Union[Path, str],
+        local_path: Path | str,
         calculate_checksum=False,
         verify_checksum=False,
         force=False,
         timeout=None,
         tries=1,
     ) -> DataObject:
-        item = self._to_dict()
+        item = self.to_dict()
 
         prev = None
         if self.exists():
@@ -2425,13 +2474,10 @@ class DataObject(RodsItem):
 
         return self
 
-    def _list(self, **kwargs) -> List[dict]:
-        item = self._to_dict()
+    def _list(self, **kwargs) -> list[dict]:
+        item = self.to_dict()
         with client(self.pool) as c:
             return c.list(item, **kwargs)
-
-    def _to_dict(self) -> Dict:
-        return {Baton.COLL: self.path, Baton.OBJ: self.name}
 
     def __eq__(self, other):
         if not isinstance(other, DataObject):
@@ -2490,7 +2536,11 @@ class Collection(RodsItem):
         return collections
 
     def __init__(
-        self, remote_path: Union[PurePath, str], check_type=True, pool=default_pool
+        self,
+        remote_path: PurePath | str,
+        local_path: Path | str = None,
+        check_type=True,
+        pool=default_pool,
     ):
         """Collection constructor.
 
@@ -2499,7 +2549,9 @@ class Collection(RodsItem):
             check_type: Check the remote path type if True, defaults to True.
             pool: A baton client pool. Optional.
         """
-        super().__init__(remote_path, check_type=check_type, pool=pool)
+        super().__init__(
+            remote_path, local_path=local_path, check_type=check_type, pool=pool
+        )
 
     def create(
         self, parents=False, exist_ok=False, timeout=None, tries=1
@@ -2518,7 +2570,7 @@ class Collection(RodsItem):
         if exist_ok and self.exists():
             return self
 
-        item = self._to_dict()
+        item = self.to_dict()
         with client(self.pool) as c:
             c.create_collection(item, parents=parents, timeout=timeout, tries=tries)
         return self
@@ -2542,7 +2594,7 @@ class Collection(RodsItem):
     @rods_type_check
     def contents(
         self, acl=False, avu=False, recurse=False, timeout=None, tries=1
-    ) -> List[Union[DataObject, Collection]]:
+    ) -> list[Collection | DataObject]:
         """Return a list of the Collection contents.
 
         Args:
@@ -2589,7 +2641,7 @@ class Collection(RodsItem):
     @rods_type_check
     def iter_contents(
         self, acl=False, avu=False, recurse=False, timeout=None, tries=1
-    ) -> Iterable[Union[DataObject, Collection]]:
+    ) -> Iterable[Collection | DataObject]:
         """Return a generator for the Collection contents.
 
         Args:
@@ -2599,7 +2651,7 @@ class Collection(RodsItem):
           timeout: Operation timeout in seconds.
           tries: Number of times to try the operation.
 
-        Returns: Iterable[Union[DataObject, Collection]]"""
+        Returns: Iterable[Collection | DataObject]"""
         items = self._list(
             acl=acl,
             avu=avu,
@@ -2640,7 +2692,7 @@ class Collection(RodsItem):
         return _make_rods_item(item, pool=self.pool)
 
     @rods_type_check
-    def get(self, local_path: Union[Path, str], **kwargs):
+    def get(self, local_path: Path | str, **kwargs):
         """Get the collection and contents from iRODS and save to a local directory.
 
         Args:
@@ -2652,7 +2704,7 @@ class Collection(RodsItem):
 
     def put(
         self,
-        local_path: Union[Path, str],
+        local_path: Path | str,
         recurse=False,
         calculate_checksum=False,
         verify_checksum=False,
@@ -2785,7 +2837,7 @@ class Collection(RodsItem):
 
     def supersede_permissions(
         self, *acs: AC, recurse=False, timeout=None, tries=1
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Remove all access controls from the collection, replacing them with the
         specified access controls. Return the numbers of access controls
         removed and added.
@@ -2808,12 +2860,15 @@ class Collection(RodsItem):
                 num_added += na
         return num_removed, num_added
 
-    def _list(self, **kwargs) -> List[dict]:
-        with client(self.pool) as c:
-            return c.list({Baton.COLL: self.path}, **kwargs)
+    def to_dict(self) -> dict:
+        return {Baton.COLL: self.path.as_posix()}
 
-    def _to_dict(self):
-        return {Baton.COLL: self.path}
+    def to_json(self, **kwargs) -> str:
+        return json.dumps(self, cls=BatonJSONEncoder, **kwargs)
+
+    def _list(self, **kwargs) -> list[dict]:
+        with client(self.pool) as c:
+            return c.list(self.to_dict(), **kwargs)
 
     def __eq__(self, other):
         if not isinstance(other, Collection):
@@ -2830,16 +2885,52 @@ class Collection(RodsItem):
     def __repr__(self):
         return self.path.as_posix()
 
+    @classmethod
+    def from_json(cls, s: str):
+        o = json.loads(s, cls=BatonJSONDecoder)
+        if isinstance(o, Collection):
+            return o
+
+        raise ValueError(f"Expected a Collection, got {type(o)}")
+
 
 class BatonJSONEncoder(json.JSONEncoder):
-    """Encoder for baton JSON."""
+    """Encoder for baton JSON.
+
+    This encoder is general-purpose. It is used to serialise Python objects before
+    passing them to the baton client."""
 
     def default(self, o: Any) -> Any:
+        if isinstance(o, Collection):
+            enc = {
+                Baton.COLL: o.path,
+                Baton.AVUS: o.metadata(),
+                Baton.ACCESS: o.acl(),
+            }
+            if o.local_path is not None:
+                enc[Baton.DIR] = o.local_path
+            return enc
+
+        if isinstance(o, DataObject):
+            enc = {
+                Baton.COLL: o.path,
+                Baton.OBJ: o.name,
+                Baton.AVUS: o.metadata(),
+                Baton.ACCESS: o.acl(),
+            }
+            if o.local_path is not None:
+                enc[Baton.DIR] = o.dir
+                enc[Baton.FILE] = o.file
+
+            enc[Baton.SIZE] = o.size()
+            enc[Baton.CHECKSUM] = o.checksum()
+            return enc
+
         if isinstance(o, AVU):
             enc = {Baton.ATTRIBUTE: o.attribute, Baton.VALUE: o.value}
             if o.units:
                 enc[Baton.UNITS] = o.units
-            if o.operator:
+            if o.operator and o.operator != "=":
                 enc[Baton.OPERATOR] = o.operator
             return enc
 
@@ -2853,19 +2944,20 @@ class BatonJSONEncoder(json.JSONEncoder):
                 Baton.LEVEL: o.perm,
             }
 
-        if isinstance(o, PurePath):
+        if isinstance(o, Path | PurePath):
             return o.as_posix()
 
+        return super().default(o)
 
-def as_baton(d: Dict) -> Any:
-    """Object hook for decoding baton JSON."""
+
+def as_baton(d: dict) -> Any:
+    """Object hook for partially decoding baton JSON (just AVUs and ACs)."""
 
     # Match an AVU sub-document
     if Baton.ATTRIBUTE in d:
         attr = d[Baton.ATTRIBUTE]
         value = d[Baton.VALUE]
         units = d.get(Baton.UNITS, None)
-
         return AVU(attr, value, units)
 
     # Match an access permission sub-document
@@ -2879,11 +2971,43 @@ def as_baton(d: Dict) -> Any:
     return d
 
 
-def _make_rods_item(item: Dict, pool: BatonPool) -> Union[DataObject, Collection]:
+class BatonJSONDecoder(json.JSONDecoder):
+    """Decoder for baton JSON.
+
+    This decoder is not general-purpose. It is used to deserialise JSON from sources
+    outside the context of an iRODS connection, e.g. from a file or pipe. It does
+    not set a baton client pool for the objects it creates.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(object_hook=self.object_hook, *args, **kwargs)
+
+    @staticmethod
+    def object_hook(d: dict) -> Any:
+        match d:
+            case {Baton.COLL: c, Baton.OBJ: o}:
+                log.debug(f"Making a DataObject from {d}")
+                return DataObject(PurePath(c, o))
+            case {Baton.COLL: c}:
+                log.debug(f"Making a Collection from {d}")
+                return Collection(PurePath(c))
+
+            case {Baton.AVUS: x}:
+                log.debug(f"Making AVUs from {d}")
+                return [as_baton(elt) for elt in x]
+
+            case {Baton.ACCESS: x}:
+                log.debug(f"Making ACs from {d}")
+                return [as_baton(elt) for elt in x]
+            case _:
+                return d
+
+
+def _make_rods_item(item: dict, pool: BatonPool) -> Collection | DataObject:
     """Create a new Collection or DataObject as appropriate for a dictionary
     returned by a Baton.
 
-    Returns: Union[DataObject, Collection]
+    Returns: Collection | DataObject
     """
     match item:
         case {Baton.COLL: c, Baton.OBJ: o}:
@@ -2897,7 +3021,7 @@ def _make_rods_item(item: Dict, pool: BatonPool) -> Union[DataObject, Collection
             raise BatonError(f"{Baton.COLL} key missing from {item}")
 
 
-def _calculate_local_checksum(local_path: Union[Path, str]) -> str:
+def _calculate_local_checksum(local_path: Path | str) -> str:
     """Calculate the MD5 checksum of a local file.
 
     Args:

--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1304,6 +1304,7 @@ def rods_users(user_type: str = None, zone=None) -> list[User]:
     """
     if user_type is not None and user_type not in [
         "rodsadmin",
+        "groupadmin",
         "rodsgroup",
         "rodsuser",
     ]:

--- a/src/partisan/irods.py
+++ b/src/partisan/irods.py
@@ -1447,10 +1447,10 @@ class RodsItem(PathLike):
     ability to be serialized/deserialized to/from JSON, including their metadata and
     ACLs.
 
-    The decision to connect or not made on instance construction by passing a BatonPool
+    The decision to connect or not is made on instance construction by passing a BatonPool
     and cannot be changed later. This is to avoid the complexity of reconciling the two
     sets of metadata and ACLs (local and remote) that would be required. The best way
-    to convert bn item from disconnected to connected is to create a new instance with
+    to convert an item from disconnected to connected is to create a new instance with
     the same path and a pool, then copy the metadata and ACLs across.
     """
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,9 +61,10 @@ class TestBatonClient(object):
         assert c.is_running()
         pid = c.pid()
 
-        c.list({Baton.COLL: simple_collection})
-        c.list({Baton.COLL: simple_collection})
-        c.list({Baton.COLL: simple_collection})
+        arg = {Baton.COLL: simple_collection.as_posix()}
+        assert c.list(arg) == [arg]
+        assert c.list(arg) == [arg]
+        assert c.list(arg) == [arg]
 
         assert c.is_running()
         assert c.pid() == pid

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -18,6 +18,7 @@
 # @author Keith James <kdj@sanger.ac.uk>
 
 import hashlib
+import json
 import os.path
 from datetime import datetime, timezone
 from pathlib import Path, PurePath
@@ -30,6 +31,7 @@ from partisan.exception import BatonError, RodsError
 from partisan.irods import (
     AC,
     AVU,
+    Baton,
     Collection,
     DataObject,
     Permission,
@@ -1448,3 +1450,79 @@ class TestSpecialPath:
         coll = Collection(special_paths)
         observed = [str(x) for x in coll.contents(recurse=True)]
         assert observed == expected
+
+
+@m.describe("JSON serialization")
+class TestJSON:
+    @m.it("Can serialize a collection to JSON")
+    def test_collection_json_serialize(self, simple_collection):
+        coll = Collection(simple_collection)
+        coll.add_metadata(AVU("a", 1), AVU("b", 2), AVU("c", 3))
+
+        kwargs = {"indent": None, "sort_keys": True}
+
+        assert coll.to_json(**kwargs) == json.dumps(
+            {
+                Baton.COLL: coll.path.as_posix(),
+                Baton.AVUS: [
+                    {Baton.ATTRIBUTE: "a", Baton.VALUE: "1"},
+                    {Baton.ATTRIBUTE: "b", Baton.VALUE: "2"},
+                    {Baton.ATTRIBUTE: "c", Baton.VALUE: "3"},
+                ],
+                Baton.ACCESS: [
+                    {Baton.OWNER: "irods", Baton.ZONE: "testZone", Baton.LEVEL: "own"}
+                ],
+            },
+            **kwargs,
+        )
+
+    def test_collection_json_deserialize(self, simple_collection):
+        coll1 = Collection(simple_collection)
+        coll1.add_metadata(AVU("a", 1), AVU("b", 2), AVU("c", 3))
+
+        json_str = coll1.to_json(indent=None, sort_keys=True)
+
+        coll2 = Collection.from_json(json_str)
+        assert coll2.path == coll1.path
+        assert coll2.metadata() == coll1.metadata()
+        assert coll2.acl() == coll1.acl()
+
+    @m.it("Can serialize a data object to JSON")
+    def test_data_object_json_serlialize(self, simple_data_object):
+        obj = DataObject(simple_data_object)
+        obj.add_metadata(AVU("a", 1), AVU("b", 2), AVU("c", 3))
+
+        kwargs = {"indent": None, "sort_keys": True}
+
+        assert obj.to_json(**kwargs) == json.dumps(
+            {
+                Baton.COLL: obj.path.as_posix(),
+                Baton.OBJ: obj.name,
+                Baton.AVUS: [
+                    {Baton.ATTRIBUTE: "a", Baton.VALUE: "1"},
+                    {Baton.ATTRIBUTE: "b", Baton.VALUE: "2"},
+                    {Baton.ATTRIBUTE: "c", Baton.VALUE: "3"},
+                ],
+                Baton.ACCESS: [
+                    {Baton.OWNER: "irods", Baton.ZONE: "testZone", Baton.LEVEL: "own"}
+                ],
+                Baton.SIZE: 555,
+                Baton.CHECKSUM: "39a4aa291ca849d601e4e5b8ed627a04",
+            },
+            **kwargs,
+        )
+
+    @m.it("Can deserialize a data object from JSON")
+    def test_data_object_json_deserialize(self, simple_data_object):
+        obj1 = DataObject(simple_data_object)
+        obj1.add_metadata(AVU("a", 1), AVU("b", 2), AVU("c", 3))
+
+        json_str = obj1.to_json(indent=None, sort_keys=True)
+
+        obj2 = DataObject.from_json(json_str)
+        assert obj2.path == obj1.path
+        assert obj2.name == obj1.name
+        assert obj2.metadata() == obj1.metadata()
+        assert obj2.acl() == obj1.acl()
+        assert obj2.size() == obj1.size()
+        assert obj2.checksum() == obj1.checksum()

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -1489,10 +1489,22 @@ class TestJSON:
         assert coll2.acl() == coll1.acl()
 
     @m.it("Can serialize a data object to JSON")
-    def test_data_object_json_serialize(self, simple_data_object):
+    def test_data_object_json_serialize(
+        self, irods_groups, irods_users, simple_data_object
+    ):
         obj = DataObject(simple_data_object)
         assert obj.connected()
-        obj.add_metadata(AVU("a", 1), AVU("b", 2), AVU("c", 3))
+
+        metadata = [AVU("a", 1), AVU("b", 2), AVU("c", 3)]
+        acl = [
+            AC("user1", Permission.OWN, zone="testZone"),
+            AC("user2", Permission.WRITE, zone="testZone"),
+            AC("user3", Permission.WRITE, zone="testZone"),
+            AC("public", Permission.READ, zone="testZone"),
+        ]
+
+        obj.add_metadata(*metadata)
+        obj.add_permissions(*acl)
 
         kwargs = {"indent": None, "sort_keys": True}
 
@@ -1506,7 +1518,23 @@ class TestJSON:
                     {Baton.ATTRIBUTE: "c", Baton.VALUE: "3"},
                 ],
                 Baton.ACCESS: [
-                    {Baton.OWNER: "irods", Baton.ZONE: "testZone", Baton.LEVEL: "own"}
+                    {Baton.OWNER: "irods", Baton.ZONE: "testZone", Baton.LEVEL: "own"},
+                    {
+                        Baton.OWNER: "public",
+                        Baton.ZONE: "testZone",
+                        Baton.LEVEL: "read",
+                    },
+                    {Baton.OWNER: "user1", Baton.ZONE: "testZone", Baton.LEVEL: "own"},
+                    {
+                        Baton.OWNER: "user2",
+                        Baton.ZONE: "testZone",
+                        Baton.LEVEL: "write",
+                    },
+                    {
+                        Baton.OWNER: "user3",
+                        Baton.ZONE: "testZone",
+                        Baton.LEVEL: "write",
+                    },
                 ],
                 Baton.SIZE: 555,
                 Baton.CHECKSUM: "39a4aa291ca849d601e4e5b8ed627a04",

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -1476,6 +1476,7 @@ class TestJSON:
             **kwargs,
         )
 
+    @m.it("Can deserialize a collection from JSON")
     def test_collection_json_deserialize(self, simple_collection):
         coll1 = Collection(simple_collection)
         coll1.add_metadata(AVU("a", 1), AVU("b", 2), AVU("c", 3))


### PR DESCRIPTION
Add to_json/from_json methods to Collectiona and DataObject and allow those to exist disconnected from iRODS to enable `baton` JSON to be written/read by Python applications.