### PR TITLE
Avoid using a Docker volume during tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,8 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     restart: always
-    volumes:
-      - "./tests/.irods:/home/appuser/.irods/"
     environment:
-      IRODS_ENVIRONMENT_FILE: "/home/appuser/.irods/irods_environment.json"
+      IRODS_ENVIRONMENT_FILE: "/app/tests/.irods/irods_environment.json"
       IRODS_PASSWORD: "irods"
       IRODS_VERSION: "4.2.11"
     depends_on:

--- a/tests/.irods/irods_environment.json
+++ b/tests/.irods/irods_environment.json
@@ -2,7 +2,6 @@
     "irods_host": "irods-server",
     "irods_port": 1247,
     "irods_user_name": "irods",
-    "irods_authentication_file": "./tests/.irods/auth_file",
     "irods_zone_name": "testZone",
     "irods_home": "/testZone/home/irods",
     "irods_default_resource": "replResc",


### PR DESCRIPTION
For the benefit of Linux users whose UID does not match the appuser UID (1000) inside the test container and who therefore have to work around this by mapping UIDs; avoid mounting the iRODS environment file into the container in the first place, thereby avoiding the problem.