### PR TITLE
Add the option to capture exceptions from Collection::put

### DIFF
--- a/docker/install_pyenv.sh
+++ b/docker/install_pyenv.sh
@@ -8,7 +8,7 @@ export PYENV_GIT_TAG="v${PYENV_RELEASE_VERSION}"
 PYENV_ROOT=${PYENV_ROOT:-"$HOME/.pyenv"}
 export PATH="$PYENV_ROOT/bin:$PATH"
 
-PYENV_SHA256="a1ad63c22842dce498b441551e2f83ede3e3b6ebb33f62013607bba424683191"
+PYENV_SHA256="4b0adf623a6205727163eb98610b6c5e63f23b99183948b874d867cd9b30ef13"
 curl -sSL -O https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer
 sha256sum ./pyenv-installer | grep "$PYENV_SHA256"
 /bin/bash ./pyenv-installer

--- a/tests/test_irods.py
+++ b/tests/test_irods.py
@@ -989,10 +989,12 @@ class TestCollection:
 
         sub1 = Collection(coll.path / "collection")
         child = Collection(sub1.path / "child")
+        ignore = DataObject(child.path / ".gitignore")
 
-        assert items == [coll, sub1, child]
+        assert items == [coll, sub1, child, ignore]
         assert coll.contents() == [sub1]
         assert sub1.contents() == [child]
+        assert child.contents() == [ignore]
 
     @m.context("When a Collection does not exist and is put recursively")
     @m.it("Data object paths can be skipped by providing a filter predicate")


### PR DESCRIPTION
Add a keyword argument to Collection::put that causes the generator to return any Exception raised when putting an item. By returning the Exception rather than raising it, the generator can continue to do as much work as possible before completing, rather than terminating immediately. This is useful for bulk uploads where we would otherwise have to restart the whole traversal for each error. The default behaviour remains the same as it was; an exception is raised as soon as the first error is encountered.